### PR TITLE
feat(ssh): add subcommands for connection management

### DIFF
--- a/.github/workflows/internal-ci.yml
+++ b/.github/workflows/internal-ci.yml
@@ -1,6 +1,8 @@
 name: update-docs
 
-on: [ push ]
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   docs:

--- a/.github/workflows/internal-ci.yml
+++ b/.github/workflows/internal-ci.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -29,12 +30,13 @@ jobs:
 
       - name: Push changes
         run: |
-          git config --global user.name 'MagdielCAS' || exit 0
-          git config --global user.email 'magdiel.camp@gmail.com' || exit 0
-          git remote set-url origin https://x-access-token:${{ secrets.REPO_ACCESS_TOKEN }}@github.com/$GITHUB_REPOSITORY || exit 0
-          git checkout "${GITHUB_REF:11}" || exit 0
-          git add . || exit 0
-          git commit -am "docs: update docs with PTerm-CI" || exit 0
-          git push || exit 0
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          git config --global user.name 'MagdielCAS'
+          git config --global user.email 'magdiel.camp@gmail.com'
+          
+          if [[ -n $(git status -s) ]]; then
+            git add .
+            git commit -m "docs: update docs with PTerm-CI"
+            git push origin HEAD:${GITHUB_REF}
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/internal-ci.yml
+++ b/.github/workflows/internal-ci.yml
@@ -12,16 +12,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ^1.25
+          cache: true
+          cache-dependency-path: go.sum
+
       - name: Run PTerm-CI
         run: |
           go get
           go mod tidy
           go run . setup --ci
           go run . ptermCI
+
       - name: Push changes
         run: |
           git config --global user.name 'MagdielCAS' || exit 0

--- a/.github/workflows/internal-ci.yml
+++ b/.github/workflows/internal-ci.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           go get
           go mod tidy
+          go run . setup --ci
           go run . ptermCI
       - name: Push changes
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,69 @@ Whenever you add or modify a command (see `cmd/setup.go` or `cmd/config.go` for 
 4. **Golden files.** When testing AI prompt builders, store prompt templates under `testdata/` and compare outputs using `cmp.Diff`.
 5. **CI hooks.** Every PR must pass `go test ./...`, `golangci-lint run` (when enabled), and `make vet`. Document new required tooling in `README.md`.
 6. **Fixtures hygiene.** Never hardcode live API keys. Use env var placeholders (`MAGI_TEST_API_KEY`) and skip tests when prerequisites are missing.
+
+## 8. Command Pattern Agent Rules
+
+When implementing or modifying CLI commands, you **MUST** follow the repository's established pattern as defined in `docs/CONTRIBUTING.md`.
+
+### Command Structure Guidelines
+
+Every `cobra.Command` definition must include:
+
+1.  **Use**: A clear usage string (e.g., `command [args]`).
+2.  **Short**: A concise summary of what the command does.
+3.  **Long**: A detailed description that includes:
+    *   Explanation of the command's purpose and behavior.
+    *   **Available subcommands** (if applicable), listed with descriptions.
+    *   **Usage** section showing the command syntax.
+    *   **Examples** section showing common usage scenarios.
+
+### Example Pattern
+
+```go
+var cmd = &cobra.Command{
+    // Use is the one-line usage message.
+    // Recommended syntax is as follows:
+    //   [ ] identifies an optional argument. Arguments that are not enclosed in brackets are required.
+    //   ... indicates that you can specify multiple values for the previous argument.
+    //   |   indicates mutually exclusive information. You can use the argument to the left of the separator or the
+    //       argument to the right of the separator. You cannot use both arguments in a single use of the command.
+    //   { } delimits a set of mutually exclusive arguments when one of the arguments is required. If the arguments are
+    //       optional, they are enclosed in brackets ([ ]).
+    // Example: add [-F file | -D dir]... [-f format] profile
+    Use:   "my-command [arg]",
+
+    // Short is the short description shown in the 'help' output.
+    Short: "Concise summary",
+
+    // Long is the long message shown in the 'help <this-command>' output.
+    Long: `Detailed description of what the command does.
+
+Available subcommands:
+  sub1    Description of sub1
+  sub2    Description of sub2
+
+Usage:
+  magi my-command [arg]
+
+Examples:
+  # Example 1
+  magi my-command value
+
+  # Example 2
+  magi my-command --flag`,
+
+    // Run is the function called when the command is executed.
+    Run: func(cmd *cobra.Command, args []string) {
+        // Default behavior implementation
+    },
+}
+```
+
+### Checklist for New Commands
+
+- [ ] `Use` field is correct and descriptive.
+- [ ] `Short` field provides a quick summary.
+- [ ] `Long` field follows the structure: Description -> Subcommands -> Usage -> Examples.
+- [ ] Examples cover common use cases.
+- [ ] Help text is user-friendly and comprehensive.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ magi uses a configuration file located at `$HOME/.magi/config.yaml`. You can mod
 magi config [key] [value]
 ```
 
+You can also create a local configuration file for project-specific settings:
+
+```bash
+magi config init
+```
+
 ## Support
 
 - 📫 Report issues on [GitHub Issues](https://github.com/MagdielCAS/magi-cli/issues)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ import (
 var (
 	cfgFile string
 	// These variables are set at build time using ldflags
-	version = "v0.4.2" // <---VERSION---> Updating this version, will also create a new GitHub tag.
+	version = "v0.5.0" // <---VERSION---> Updating this version, will also create a new GitHub tag.
 	commit  = "none"
 	date    = "unknown"
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -158,11 +158,11 @@ func loadConfiguration() {
 			// If the config file is not found, create it if it's the default global config path
 			// or if the user explicitly specified the default global config path.
 			if cfgFile == "" || cfgFile == globalConfigPath {
-				if err = viper.SafeWriteConfig(); err != nil {
+				if err = viper.WriteConfigAs(globalConfigPath); err != nil {
 					pterm.Error.Printf("Error creating config file: %v\n", err)
 					os.Exit(1)
 				}
-				pterm.Success.Println("New config file created at " + viper.ConfigFileUsed())
+				pterm.Success.Println("New config file created at " + globalConfigPath)
 			} else {
 				// Custom config file not found
 				pterm.Error.Printf("Config file not found: %s\n", cfgFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,7 +154,7 @@ func loadConfiguration() {
 	}
 
 	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok || os.IsNotExist(err) {
 			// If the config file is not found, create it if it's the default global config path
 			// or if the user explicitly specified the default global config path.
 			if cfgFile == "" || cfgFile == globalConfigPath {

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,12 @@ magi uses a configuration file located at `$HOME/.magi/config.yaml`. You can mod
 magi config [key] [value]
 ```
 
+You can also create a local configuration file for project-specific settings:
+
+```bash
+magi config init
+```
+
 ## Support
 
 - 📫 Report issues on [GitHub Issues](https://github.com/MagdielCAS/magi-cli/issues)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -51,6 +51,7 @@ Run 'magi [command] --help' for more information on a specific command.
 |`magi pr`|Review local commits with AI agents and open a GitHub pull request|
 |`magi push`|Push the current branch and auto-configure the upstream if needed|
 |`magi setup`|Starts an interactive setup wizard for magi|
+|`magi ssh`|Manage and connect to SSH servers|
 |`magi version`|Shows the version of magi|
 # ... commit
 `magi commit`
@@ -404,10 +405,159 @@ Examples:
 |`--api-key string`|Your OpenAI API key|
 |`--api-provider string`|API provider (e.g., openai, custom)|
 |`--base-url string`|Base URL for custom OpenAI compatible API|
+|`--ci`|Run setup in CI mode (non-interactive, uses defaults)|
 |`--fallback-model string`|Fallback model (e.g., gpt-3.5-turbo)|
 |`--format string`|Default output format (e.g., text, json, yaml)|
 |`--heavy-model string`|Model for heavy tasks (e.g., gpt-4)|
 |`--light-model string`|Model for light tasks (e.g., gpt-3.5-turbo)|
+# ... ssh
+`magi ssh`
+
+## Usage
+> Manage and connect to SSH servers
+
+magi ssh
+
+## Description
+
+```
+A comprehensive SSH connection management system.
+Allows you to add, connect, list, and remove SSH connections with ease.
+
+Available subcommands:
+  add         Add a new SSH connection
+  connect     Connect to a saved SSH server
+  list        List all saved SSH connections
+  remove      Remove a saved SSH connection
+
+Usage:
+  magi ssh [command]
+```
+## Examples
+
+```bash
+  # Add a new connection
+  magi ssh add
+
+  # Connect to a saved server
+  magi ssh connect my-server
+
+  # List all connections
+  magi ssh list
+```
+
+## Commands
+|Command|Usage|
+|-------|-----|
+|`magi ssh add`|Add a new SSH connection|
+|`magi ssh connect`|Connect to a saved SSH server|
+|`magi ssh list`|List all saved SSH connections|
+|`magi ssh remove`|Remove a saved SSH connection|
+# ... ssh add
+`magi ssh add`
+
+## Usage
+> Add a new SSH connection
+
+magi ssh add
+
+## Description
+
+```
+Interactive wizard to add a new SSH connection configuration.
+
+This command will prompt you for:
+- Connection Alias (unique name)
+- SSH Key (select existing or add new)
+- Server IP
+- Username (default: ubuntu)
+- Port (default: 22)
+
+Usage:
+  magi ssh add
+
+Examples:
+  # Start the interactive add wizard
+  magi ssh add
+```
+# ... ssh connect
+`magi ssh connect`
+
+## Usage
+> Connect to a saved SSH server
+
+magi ssh connect [alias]
+
+## Description
+
+```
+Connect to a saved SSH server using its alias.
+
+If no alias is provided, an interactive list of available connections will be shown.
+
+Usage:
+  magi ssh connect [alias]
+
+Examples:
+  # Connect using a specific alias
+  magi ssh connect prod-db
+
+  # Select from a list of connections
+  magi ssh connect
+```
+# ... ssh list
+`magi ssh list`
+
+## Usage
+> List all saved SSH connections
+
+magi ssh list
+
+## Description
+
+```
+Display a table of all saved SSH connections.
+
+The table includes:
+- Alias
+- IP Address
+- Username
+- Port
+- Key Path
+
+Usage:
+  magi ssh list
+
+Examples:
+  # List all connections
+  magi ssh list
+```
+# ... ssh remove
+`magi ssh remove`
+
+## Usage
+> Remove a saved SSH connection
+
+magi ssh remove [alias]
+
+## Description
+
+```
+Remove a saved SSH connection by its alias.
+
+If no alias is provided, an interactive list of connections will be shown to select from.
+You will be prompted for confirmation before the connection is deleted.
+
+Usage:
+  magi ssh remove [alias]
+
+Examples:
+  # Remove a specific connection
+  magi ssh remove prod-db
+
+  # Select a connection to remove
+  magi ssh remove
+```
 # ... version
 `magi version`
 

--- a/internal/cli/ssh/add.go
+++ b/internal/cli/ssh/add.go
@@ -1,0 +1,244 @@
+package ssh
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func addCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a new SSH connection",
+		Long: `Interactive wizard to add a new SSH connection configuration.
+
+This command will prompt you for:
+- Connection Alias (unique name)
+- SSH Key (select existing or add new)
+- Server IP
+- Username (default: ubuntu)
+- Port (default: 22)
+
+Usage:
+  magi ssh add
+
+Examples:
+  # Start the interactive add wizard
+  magi ssh add`,
+		Run: func(cmd *cobra.Command, args []string) {
+			addConnection()
+		},
+	}
+	return cmd
+}
+
+func addConnection() {
+	pterm.DefaultHeader.WithFullWidth().Println("SSH Connection Add")
+
+	// 1. Alias
+	alias, err := promptForAlias()
+	if err != nil {
+		pterm.Error.Println(err)
+		return
+	}
+
+	// 2. SSH Key
+	keyPath, err := selectOrAddSSHKey()
+	if err != nil {
+		pterm.Error.Println(err)
+		return
+	}
+
+	// 3. Connection Details
+	conn, err := collectConnectionConfig(alias, keyPath)
+	if err != nil {
+		pterm.Error.Println(err)
+		return
+	}
+
+	// 4. Save
+	if err := saveConnection(conn); err != nil {
+		pterm.Error.Printf("Failed to save connection: %v\n", err)
+		return
+	}
+
+	pterm.Success.Printf("Connection '%s' saved successfully!\n", alias)
+}
+
+func promptForAlias() (string, error) {
+	var alias string
+	var err error
+
+	existing := viper.GetStringMap(ConfigSSHConnections)
+
+	aliasRegex := regexp.MustCompile("^[a-zA-Z0-9_-]+$")
+
+	for {
+		alias, err = pterm.DefaultInteractiveTextInput.WithDefaultText("Connection Alias").Show()
+		if err != nil {
+			return "", err
+		}
+
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			pterm.Warning.Println("Alias cannot be empty")
+			continue
+		}
+
+		// Check for valid characters (alphanumeric, -, _)
+		if !aliasRegex.MatchString(alias) {
+			pterm.Warning.Println("Alias can only contain letters, numbers, hyphens, and underscores")
+			continue
+		}
+
+		if _, exists := existing[alias]; exists {
+			overwrite, _ := pterm.DefaultInteractiveConfirm.WithDefaultText(fmt.Sprintf("Alias '%s' already exists. Overwrite?", alias)).Show()
+			if !overwrite {
+				continue
+			}
+		}
+		break
+	}
+	return alias, nil
+}
+
+func selectOrAddSSHKey() (string, error) {
+	keys := viper.GetStringSlice(ConfigSSHKeys)
+	options := append([]string{"Add new key path"}, keys...)
+
+	selection, err := pterm.DefaultInteractiveSelect.
+		WithDefaultText("Select SSH Key").
+		WithOptions(options).
+		Show()
+	if err != nil {
+		return "", err
+	}
+
+	if selection == "Add new key path" {
+		return promptForNewKey()
+	}
+
+	return selection, nil
+}
+
+func promptForNewKey() (string, error) {
+	for {
+		path, err := pterm.DefaultInteractiveTextInput.WithDefaultText("Enter absolute path to private key").Show()
+		if err != nil {
+			return "", err
+		}
+
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+
+		// Expand ~ if present
+		if strings.HasPrefix(path, "~/") {
+			home, _ := os.UserHomeDir()
+			path = filepath.Join(home, path[2:])
+		}
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			pterm.Warning.Printf("File does not exist: %s\n", path)
+			continue
+		}
+
+		// Save new key to list if not exists
+		keys := viper.GetStringSlice(ConfigSSHKeys)
+		exists := false
+		for _, k := range keys {
+			if k == path {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			keys = append(keys, path)
+			viper.Set(ConfigSSHKeys, keys)
+		}
+
+		return path, nil
+	}
+}
+
+func collectConnectionConfig(alias, keyPath string) (SSHConnection, error) {
+	// IP
+	var ip string
+	var err error
+	for {
+		ip, err = pterm.DefaultInteractiveTextInput.WithDefaultText("Server IP").Show()
+		if err != nil {
+			return SSHConnection{}, err
+		}
+		if net.ParseIP(ip) == nil {
+			pterm.Warning.Println("Invalid IP address")
+			continue
+		}
+		break
+	}
+
+	// Username
+	username, err := pterm.DefaultInteractiveTextInput.
+		WithDefaultText("Username").
+		WithDefaultValue(DefaultUser).
+		Show()
+	if err != nil {
+		return SSHConnection{}, err
+	}
+	if username == "" {
+		username = DefaultUser
+	}
+
+	// Port
+	var port int
+	for {
+		portStr, err := pterm.DefaultInteractiveTextInput.
+			WithDefaultText("Port").
+			WithDefaultValue(strconv.Itoa(DefaultPort)).
+			Show()
+		if err != nil {
+			return SSHConnection{}, err
+		}
+
+		p, err := strconv.Atoi(portStr)
+		if err != nil || p < MinPort || p > MaxPort {
+			pterm.Warning.Printf("Port must be between %d and %d\n", MinPort, MaxPort)
+			continue
+		}
+		port = p
+		break
+	}
+
+	return SSHConnection{
+		Alias:    alias,
+		KeyPath:  keyPath,
+		IP:       ip,
+		Username: username,
+		Port:     port,
+	}, nil
+}
+
+func saveConnection(conn SSHConnection) error {
+	var connMap map[string]SSHConnection
+	if err := viper.UnmarshalKey(ConfigSSHConnections, &connMap); err != nil {
+		// If unmarshal fails (e.g. empty), initialize map
+		connMap = make(map[string]SSHConnection)
+	}
+	if connMap == nil {
+		connMap = make(map[string]SSHConnection)
+	}
+
+	connMap[conn.Alias] = conn
+	viper.Set(ConfigSSHConnections, connMap)
+
+	return viper.WriteConfig()
+}

--- a/internal/cli/ssh/command.go
+++ b/internal/cli/ssh/command.go
@@ -1,0 +1,40 @@
+package ssh
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// SSHCmd represents the base ssh command
+func SSHCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ssh",
+		Short: "Manage and connect to SSH servers",
+		Long: `A comprehensive SSH connection management system.
+Allows you to add, connect, list, and remove SSH connections with ease.
+
+Available subcommands:
+  add         Add a new SSH connection
+  connect     Connect to a saved SSH server
+  list        List all saved SSH connections
+  remove      Remove a saved SSH connection
+
+Usage:
+  magi ssh [command]`,
+		Example: `  # Add a new connection
+  magi ssh add
+
+  # Connect to a saved server
+  magi ssh connect my-server
+
+  # List all connections
+  magi ssh list`,
+	}
+
+	// Register subcommands
+	cmd.AddCommand(addCmd())
+	cmd.AddCommand(connectCmd())
+	cmd.AddCommand(listCmd())
+	cmd.AddCommand(removeCmd())
+
+	return cmd
+}

--- a/internal/cli/ssh/connect.go
+++ b/internal/cli/ssh/connect.go
@@ -1,0 +1,122 @@
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func connectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "connect [alias]",
+		Short: "Connect to a saved SSH server",
+		Long: `Connect to a saved SSH server using its alias.
+
+If no alias is provided, an interactive list of available connections will be shown.
+
+Usage:
+  magi ssh connect [alias]
+
+Examples:
+  # Connect using a specific alias
+  magi ssh connect prod-db
+
+  # Select from a list of connections
+  magi ssh connect`,
+		Run: func(cmd *cobra.Command, args []string) {
+			alias := ""
+			if len(args) > 0 {
+				alias = args[0]
+			}
+			connectToHost(alias)
+		},
+	}
+	return cmd
+}
+
+func connectToHost(alias string) {
+	var conn SSHConnection
+	var err error
+
+	if alias == "" {
+		alias, conn, err = selectConnection()
+		if err != nil {
+			pterm.Error.Println(err)
+			return
+		}
+	} else {
+		conn, err = getConnection(alias)
+		if err != nil {
+			pterm.Error.Println(err)
+			return
+		}
+	}
+
+	pterm.Info.Printf("Connecting to %s (%s)...\n", alias, conn.IP)
+
+	if err := executeSSHConnection(conn); err != nil {
+		pterm.Error.Printf("Connection failed: %v\n", err)
+	}
+}
+
+func selectConnection() (string, SSHConnection, error) {
+	var connMap map[string]SSHConnection
+	if err := viper.UnmarshalKey(ConfigSSHConnections, &connMap); err != nil {
+		return "", SSHConnection{}, fmt.Errorf("failed to load connections: %w", err)
+	}
+
+	if len(connMap) == 0 {
+		return "", SSHConnection{}, fmt.Errorf("no connections found. Run 'magi ssh add' to add one")
+	}
+
+	var aliases []string
+	for k := range connMap {
+		aliases = append(aliases, k)
+	}
+	sort.Strings(aliases)
+
+	selection, err := pterm.DefaultInteractiveSelect.
+		WithDefaultText("Select connection").
+		WithOptions(aliases).
+		Show()
+	if err != nil {
+		return "", SSHConnection{}, err
+	}
+
+	return selection, connMap[selection], nil
+}
+
+func getConnection(alias string) (SSHConnection, error) {
+	var connMap map[string]SSHConnection
+	if err := viper.UnmarshalKey(ConfigSSHConnections, &connMap); err != nil {
+		return SSHConnection{}, fmt.Errorf("failed to load connections: %w", err)
+	}
+
+	conn, ok := connMap[alias]
+	if !ok {
+		return SSHConnection{}, fmt.Errorf("connection '%s' not found", alias)
+	}
+	return conn, nil
+}
+
+func executeSSHConnection(conn SSHConnection) error {
+	// Build SSH command
+	// ssh -i keyPath user@ip -p port
+	args := []string{
+		"-i", conn.KeyPath,
+		"-p", fmt.Sprintf("%d", conn.Port),
+		fmt.Sprintf("%s@%s", conn.Username, conn.IP),
+	}
+
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/internal/cli/ssh/connect.go
+++ b/internal/cli/ssh/connect.go
@@ -28,40 +28,46 @@ Examples:
 
   # Select from a list of connections
   magi ssh connect`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			alias := ""
 			if len(args) > 0 {
 				alias = args[0]
 			}
-			connectToHost(alias)
+
+			if err := connectToHost(alias); err != nil {
+				pterm.Error.Println(err)
+				return err
+			}
+
+			return nil
 		},
 	}
 	return cmd
 }
 
-func connectToHost(alias string) {
+func connectToHost(alias string) error {
 	var conn SSHConnection
 	var err error
 
 	if alias == "" {
 		alias, conn, err = selectConnection()
 		if err != nil {
-			pterm.Error.Println(err)
-			return
+			return err
 		}
 	} else {
 		conn, err = getConnection(alias)
 		if err != nil {
-			pterm.Error.Println(err)
-			return
+			return err
 		}
 	}
 
 	pterm.Info.Printf("Connecting to %s (%s)...\n", alias, conn.IP)
 
 	if err := executeSSHConnection(conn); err != nil {
-		pterm.Error.Printf("Connection failed: %v\n", err)
+		return fmt.Errorf("connection failed: %w", err)
 	}
+
+	return nil
 }
 
 func selectConnection() (string, SSHConnection, error) {

--- a/internal/cli/ssh/constants.go
+++ b/internal/cli/ssh/constants.go
@@ -1,0 +1,38 @@
+package ssh
+
+import "errors"
+
+const (
+	// Config Keys
+	ConfigSSHConnections = "ssh_connections"
+	ConfigSSHKeys        = "ssh_keys"
+
+	// Defaults
+	DefaultPort = 22
+	DefaultUser = "ubuntu"
+
+	// Validation Limits
+	MinPort = 1
+	MaxPort = 65535
+)
+
+var (
+	// Errors
+	ErrAliasExists      = errors.New("connection alias already exists")
+	ErrAliasNotFound    = errors.New("connection alias not found")
+	ErrInvalidIP        = errors.New("invalid IP address")
+	ErrInvalidPort      = errors.New("invalid port number")
+	ErrKeyNotFound      = errors.New("SSH key file not found")
+	ErrEmptyAlias       = errors.New("alias cannot be empty")
+	ErrInvalidAlias     = errors.New("alias contains invalid characters")
+	ErrConnectionFailed = errors.New("failed to establish SSH connection")
+)
+
+// SSHConnection represents a saved SSH connection configuration
+type SSHConnection struct {
+	Alias    string `mapstructure:"alias" json:"alias"`
+	KeyPath  string `mapstructure:"key_path" json:"key_path"`
+	IP       string `mapstructure:"ip" json:"ip"`
+	Username string `mapstructure:"username" json:"username"`
+	Port     int    `mapstructure:"port" json:"port"`
+}

--- a/internal/cli/ssh/list.go
+++ b/internal/cli/ssh/list.go
@@ -1,0 +1,73 @@
+package ssh
+
+import (
+	"sort"
+	"strconv"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func listCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all saved SSH connections",
+		Long: `Display a table of all saved SSH connections.
+
+The table includes:
+- Alias
+- IP Address
+- Username
+- Port
+- Key Path
+
+Usage:
+  magi ssh list
+
+Examples:
+  # List all connections
+  magi ssh list`,
+		Run: func(cmd *cobra.Command, args []string) {
+			listConnections()
+		},
+	}
+	return cmd
+}
+
+func listConnections() {
+	var connMap map[string]SSHConnection
+	if err := viper.UnmarshalKey(ConfigSSHConnections, &connMap); err != nil {
+		pterm.Error.Printf("Failed to load connections: %v\n", err)
+		return
+	}
+
+	if len(connMap) == 0 {
+		pterm.Info.Println("No SSH connections found. Run 'magi ssh add' to add one.")
+		return
+	}
+
+	// Prepare table data
+	data := [][]string{
+		{"Alias", "IP", "User", "Port", "Key Path"},
+	}
+
+	var aliases []string
+	for k := range connMap {
+		aliases = append(aliases, k)
+	}
+	sort.Strings(aliases)
+
+	for _, alias := range aliases {
+		conn := connMap[alias]
+		data = append(data, []string{
+			conn.Alias,
+			conn.IP,
+			conn.Username,
+			strconv.Itoa(conn.Port),
+			conn.KeyPath,
+		})
+	}
+
+	pterm.DefaultTable.WithHasHeader().WithData(data).Render()
+}

--- a/internal/cli/ssh/remove.go
+++ b/internal/cli/ssh/remove.go
@@ -1,0 +1,95 @@
+package ssh
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func removeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove [alias]",
+		Short: "Remove a saved SSH connection",
+		Long: `Remove a saved SSH connection by its alias.
+
+If no alias is provided, an interactive list of connections will be shown to select from.
+You will be prompted for confirmation before the connection is deleted.
+
+Usage:
+  magi ssh remove [alias]
+
+Examples:
+  # Remove a specific connection
+  magi ssh remove prod-db
+
+  # Select a connection to remove
+  magi ssh remove`,
+		Run: func(cmd *cobra.Command, args []string) {
+			alias := ""
+			if len(args) > 0 {
+				alias = args[0]
+			}
+			removeConnection(alias)
+		},
+	}
+	return cmd
+}
+
+func removeConnection(alias string) {
+	var connMap map[string]SSHConnection
+	if err := viper.UnmarshalKey(ConfigSSHConnections, &connMap); err != nil {
+		pterm.Error.Printf("Failed to load connections: %v\n", err)
+		return
+	}
+
+	if len(connMap) == 0 {
+		pterm.Info.Println("No SSH connections found.")
+		return
+	}
+
+	if alias == "" {
+		// Interactive selection
+		var aliases []string
+		for k := range connMap {
+			aliases = append(aliases, k)
+		}
+		sort.Strings(aliases)
+
+		var err error
+		alias, err = pterm.DefaultInteractiveSelect.
+			WithDefaultText("Select connection to remove").
+			WithOptions(aliases).
+			Show()
+		if err != nil {
+			pterm.Error.Println(err)
+			return
+		}
+	}
+
+	if _, exists := connMap[alias]; !exists {
+		pterm.Error.Printf("Connection '%s' not found\n", alias)
+		return
+	}
+
+	confirm, _ := pterm.DefaultInteractiveConfirm.
+		WithDefaultText(fmt.Sprintf("Are you sure you want to remove '%s'?", alias)).
+		Show()
+
+	if !confirm {
+		pterm.Info.Println("Operation cancelled")
+		return
+	}
+
+	delete(connMap, alias)
+	viper.Set(ConfigSSHConnections, connMap)
+
+	if err := viper.WriteConfig(); err != nil {
+		pterm.Error.Printf("Failed to save config: %v\n", err)
+		return
+	}
+
+	pterm.Success.Printf("Connection '%s' removed successfully\n", alias)
+}

--- a/internal/cli/ssh/ssh_test.go
+++ b/internal/cli/ssh/ssh_test.go
@@ -1,0 +1,70 @@
+package ssh
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSHCmd(t *testing.T) {
+	cmd := SSHCmd()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "ssh", cmd.Use)
+	assert.True(t, cmd.HasSubCommands())
+
+	subcommands := cmd.Commands()
+	subcommandNames := make(map[string]bool)
+	for _, sub := range subcommands {
+		subcommandNames[sub.Name()] = true
+	}
+
+	assert.True(t, subcommandNames["add"])
+	assert.True(t, subcommandNames["connect"])
+	assert.True(t, subcommandNames["list"])
+	assert.True(t, subcommandNames["remove"])
+}
+
+func TestSaveAndGetConnection(t *testing.T) {
+	// Setup Viper for testing
+	viper.Reset()
+
+	// Create temp file
+	tmpFile, err := os.CreateTemp("", "config.*.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	viper.SetConfigFile(tmpFile.Name())
+
+	viper.Set(ConfigSSHConnections, map[string]interface{}{})
+
+	// Test Data
+	conn := SSHConnection{
+		Alias:    "test-server",
+		KeyPath:  "/tmp/test-key",
+		IP:       "192.168.1.1",
+		Username: "testuser",
+		Port:     2222,
+	}
+
+	// Test Save
+	err = saveConnection(conn)
+	assert.NoError(t, err)
+
+	// Test Get
+	retrievedConn, err := getConnection("test-server")
+	assert.NoError(t, err)
+	assert.Equal(t, conn, retrievedConn)
+
+	// Test Get Non-Existent
+	_, err = getConnection("non-existent")
+	assert.Error(t, err)
+}
+
+func TestGetConnection_EmptyConfig(t *testing.T) {
+	viper.Reset()
+
+	_, err := getConnection("any")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to magi-cli! 🎉

Please provide a clear and concise description of the changes in this pull request.
If applicable, link to any related issues.
-->

**Description**

Introduces magi ssh subcommands (add, list, connect, remove) for managing persistent SSH connections in Viper config (ssh_connections map of alias->SSHConnection, ssh_keys slice of paths). Integrates into root.go with config creation messaging. Follows AGENTS.md pattern. Basic tests added for cmd structure/config persistence.

Security impact: Stores plaintext IPs/users/key paths in local config (leak risk if shared). exec.Command('ssh') transmits interactive sessions over SSH (data leaves machine); safeguards: basic IP/port/alias validation, explicit args (no injection), relies on user SSH keys/PATH ssh binary (no version/perms checks).

Testing impact: Basic unit tests present; needs table-driven validation tests, integration flows, exec mocks.

Documentation impact: Missing updates to docs/commands.md (subcommands/examples/security), docs/configuration.md (new keys/warnings), docs/getting-started.md.

Code improvements needed: Extract shared GetConnections() helper, fix struct tags, use defined errors, handle partial config states.

**Related Issues**

None

**Checklist**

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/MagdielCAS/magi-cli/blob/main/docs/CONTRIBUTING.md) guidelines.
- [ ] My code follows the project's style and formatting.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the documentation to reflect my changes.

Branch under review: feat/ssh-command