### PR TITLE
feat(i18n): add command for i18n key extraction/translation from diffs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	cliCommit "github.com/MagdielCAS/magi-cli/internal/cli/commit"
 	"github.com/MagdielCAS/magi-cli/internal/cli/config"
+	"github.com/MagdielCAS/magi-cli/internal/cli/i18n"
 	"github.com/MagdielCAS/magi-cli/internal/cli/pr"
 	"github.com/MagdielCAS/magi-cli/internal/cli/push"
 	"github.com/MagdielCAS/magi-cli/internal/cli/ssh"
@@ -218,6 +219,7 @@ func init() {
 	rootCmd.AddCommand(cliCommit.CommitCmd())
 	rootCmd.AddCommand(config.ConfigCmd())
 	rootCmd.AddCommand(ssh.SSHCmd())
+	rootCmd.AddCommand(i18n.I18nCmd())
 
 	// Use https://github.com/pterm/pcli to style the output of cobra.
 	pcli.SetRepo("MagdielCAS/magi-cli")

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -48,6 +48,7 @@ Run 'magi [command] --help' for more information on a specific command.
 |`magi completion`|Generate completion script|
 |`magi config`|Manages the magi configuration|
 |`magi help`|Help about any command|
+|`magi i18n`|AI-powered i18n translation management|
 |`magi pr`|Review local commits with AI agents and open a GitHub pull request|
 |`magi push`|Push the current branch and auto-configure the upstream if needed|
 |`magi setup`|Starts an interactive setup wizard for magi|
@@ -295,6 +296,32 @@ magi help [command]
 Help provides help for any command in the application.
 Simply type magi help [path to command] for full details.
 ```
+# ... i18n
+`magi i18n`
+
+## Usage
+> AI-powered i18n translation management
+
+magi i18n
+
+## Description
+
+```
+Automates the extraction and translation of i18n keys from code changes.
+It compares the current branch with an origin branch to find new keys,
+then uses AI agents to generate translations in specified languages.
+```
+
+## Flags
+|Flag|Usage|
+|----|-----|
+|`--languages strings`|Target languages for translation (default [en,de])|
+|`--max-tokens int`|Max tokens for AI response (default 1000)|
+|`--origin string`|Origin branch to compare against (default "main")|
+|`-o, --output string`|Output file for translations (default "i18n_translations.json")|
+|`--text-format`|Use text format instead of JSON schema|
+|`--tolgee`|Generate Tolgee-compatible output files|
+|`--yes`|Auto-confirm all prompts|
 # ... pr
 `magi pr`
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -613,4 +613,4 @@ Run 'magi version --help' for more information on a specific command.
 
 
 ---
-> **Documentation automatically generated with [PTerm](https://github.com/pterm/cli-template) on 26 November 2025**
+> **Documentation automatically generated with [PTerm](https://github.com/pterm/cli-template) on 27 November 2025**

--- a/internal/cli/i18n/agents.go
+++ b/internal/cli/i18n/agents.go
@@ -1,0 +1,298 @@
+package i18n
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/MagdielCAS/magi-cli/pkg/agent"
+	"github.com/MagdielCAS/magi-cli/pkg/llm"
+)
+
+// Data Models
+
+type TranslationData struct {
+	Keys []I18nKey `json:"keys"`
+}
+
+type I18nKey struct {
+	Key          string            `json:"key"`
+	Context      string            `json:"context"`
+	Translations map[string]string `json:"translations"`
+}
+
+// Agent Implementations
+
+// KeyExtractor Agent
+type KeyExtractor struct {
+	diff string
+}
+
+func NewKeyExtractor(diff string) *KeyExtractor {
+	return &KeyExtractor{diff: diff}
+}
+
+func (a *KeyExtractor) Name() string {
+	return "key_extractor"
+}
+
+func (a *KeyExtractor) WaitForResults() []string {
+	return []string{} // No dependencies, runs first
+}
+
+func (a *KeyExtractor) Execute(input map[string]string) (string, error) {
+	var keys []I18nKey
+	lines := strings.Split(a.diff, "\n")
+
+	// Regex patterns for different i18n usage
+	// We use two capturing groups: one for single quotes, one for double quotes
+	patterns := []*regexp.Regexp{
+		// t('key') or t("key")
+		regexp.MustCompile(`(?:^|[^a-zA-Z0-9_])t\((?:'([^']+)'|"([^"]+)")\)`),
+		// i18n.t('key') or i18n.t("key")
+		regexp.MustCompile(`i18n\.t\((?:'([^']+)'|"([^"]+)")\)`),
+		// $t('key') or $t("key")
+		regexp.MustCompile(`\$t\((?:'([^']+)'|"([^"]+)")\)`),
+		// <T key="key" />
+		regexp.MustCompile(`<T[^>]+key=(?:'([^']+)'|"([^"]+)")`),
+		// <T keyName="key" />
+		regexp.MustCompile(`<T[^>]+keyName=(?:'([^']+)'|"([^"]+)")`),
+	}
+
+	for _, line := range lines {
+		// We only care about added lines
+		if !strings.HasPrefix(line, "+") {
+			continue
+		}
+
+		// Remove the "+" prefix
+		content := line[1:]
+
+		for _, pattern := range patterns {
+			matches := pattern.FindAllStringSubmatch(content, -1)
+			for _, match := range matches {
+				// match[0] is full match
+				// match[1] is single quote group
+				// match[2] is double quote group
+				var key string
+				if len(match) > 1 && match[1] != "" {
+					key = match[1]
+				} else if len(match) > 2 && match[2] != "" {
+					key = match[2]
+				}
+
+				if key != "" {
+					// Basic context extraction (just the line content for now)
+					context := strings.TrimSpace(content)
+					if len(context) > 100 {
+						context = context[:100] + "..."
+					}
+
+					keys = append(keys, I18nKey{
+						Key:     key,
+						Context: context,
+					})
+				}
+			}
+		}
+	}
+
+	// Remove duplicates
+	uniqueKeys := make(map[string]I18nKey)
+	for _, k := range keys {
+		if _, exists := uniqueKeys[k.Key]; !exists {
+			uniqueKeys[k.Key] = k
+		}
+	}
+
+	finalKeys := make([]I18nKey, 0, len(uniqueKeys))
+	for _, k := range uniqueKeys {
+		finalKeys = append(finalKeys, k)
+	}
+
+	jsonData, err := json.Marshal(finalKeys)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal keys: %w", err)
+	}
+
+	return string(jsonData), nil
+}
+
+// TranslationGenerator Agent
+type TranslationGenerator struct {
+	llmService *llm.Service
+}
+
+func NewTranslationGenerator(service *llm.Service) *TranslationGenerator {
+	return &TranslationGenerator{
+		llmService: service,
+	}
+}
+
+func (a *TranslationGenerator) Name() string {
+	return "translation_generator"
+}
+
+func (a *TranslationGenerator) WaitForResults() []string {
+	return []string{"key_extractor"}
+}
+
+func (a *TranslationGenerator) Execute(input map[string]string) (string, error) {
+	keysJSON := input["key_extractor"]
+
+	// Construct prompt
+	langs := strings.Join(languages, ", ")
+	prompt := fmt.Sprintf(`You are a professional translator.
+Translate the following i18n keys to %s.
+The input is a JSON array of keys.
+Return a JSON object with the following structure:
+{
+  "keys": [
+    {
+      "key": "original_key",
+      "context": "context if available",
+      "translations": {
+        "en": "English translation",
+        "de": "German translation",
+        ... (one key for each target language code)
+      }
+    }
+  ]
+}
+
+Input Keys:
+%s
+`, langs, keysJSON)
+
+	// Call LLM
+	req := llm.ChatCompletionRequest{
+		Messages: []llm.ChatMessage{
+			{Role: "system", Content: "You are a helpful assistant that generates i18n translations."},
+			{Role: "user", Content: prompt},
+		},
+		Temperature: 0.3,
+	}
+
+	response, err := a.llmService.ChatCompletion(context.Background(), req)
+	if err != nil {
+		return "", fmt.Errorf("LLM translation failed: %w", err)
+	}
+
+	// Clean response (remove markdown code blocks if any)
+	response = strings.TrimPrefix(response, "```json")
+	response = strings.TrimPrefix(response, "```")
+	response = strings.TrimSuffix(response, "```")
+	response = strings.TrimSpace(response)
+
+	return response, nil
+}
+
+// TranslationEnhancer Agent
+type TranslationEnhancer struct {
+	llmService *llm.Service
+}
+
+func NewTranslationEnhancer(service *llm.Service) *TranslationEnhancer {
+	return &TranslationEnhancer{
+		llmService: service,
+	}
+}
+
+func (a *TranslationEnhancer) Name() string {
+	return "translation_enhancer"
+}
+
+func (a *TranslationEnhancer) WaitForResults() []string {
+	return []string{"translation_generator"}
+}
+
+func (a *TranslationEnhancer) Execute(input map[string]string) (string, error) {
+	translationsJSON := input["translation_generator"]
+
+	// Construct prompt for enhancement
+	prompt := fmt.Sprintf(`You are a professional localization expert.
+Review the following translations and enhance them for clarity, consistency, and professional tone.
+If a context is provided, use it to ensure the translation fits the usage.
+Do not change the keys.
+Return the result in the exact same JSON structure.
+
+Input Translations:
+%s
+`, translationsJSON)
+
+	// Call LLM
+	req := llm.ChatCompletionRequest{
+		Messages: []llm.ChatMessage{
+			{Role: "system", Content: "You are a helpful assistant that enhances i18n translations."},
+			{Role: "user", Content: prompt},
+		},
+		Temperature: 0.2, // Lower temperature for consistency
+	}
+
+	response, err := a.llmService.ChatCompletion(context.Background(), req)
+	if err != nil {
+		return "", fmt.Errorf("LLM enhancement failed: %w", err)
+	}
+
+	// Clean response
+	response = strings.TrimPrefix(response, "```json")
+	response = strings.TrimPrefix(response, "```")
+	response = strings.TrimSuffix(response, "```")
+	response = strings.TrimSpace(response)
+
+	return response, nil
+}
+
+// SQLGenerator Agent
+type SQLGenerator struct{}
+
+func NewSQLGenerator() *SQLGenerator {
+	return &SQLGenerator{}
+}
+
+func (a *SQLGenerator) Name() string {
+	return "sql_generator"
+}
+
+func (a *SQLGenerator) WaitForResults() []string {
+	return []string{"translation_enhancer"}
+}
+
+func (a *SQLGenerator) Execute(input map[string]string) (string, error) {
+	translationsJSON := input["translation_enhancer"]
+
+	var translationData TranslationData
+	// Try to unmarshal as TranslationData first
+	if err := json.Unmarshal([]byte(translationsJSON), &translationData); err != nil {
+		// Try as array of keys
+		var keys []I18nKey
+		if err2 := json.Unmarshal([]byte(translationsJSON), &keys); err2 != nil {
+			return "", fmt.Errorf("failed to parse translations for SQL generation: %w", err)
+		}
+		translationData = TranslationData{Keys: keys}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("-- Auto-generated i18n SQL script\n")
+	sb.WriteString("BEGIN;\n\n")
+
+	for _, k := range translationData.Keys {
+		sb.WriteString(fmt.Sprintf("-- Key: %s\n", k.Key))
+		for lang, content := range k.Translations {
+			escapedContent := strings.ReplaceAll(content, "'", "''")
+			sb.WriteString(fmt.Sprintf("INSERT INTO i18n_translations (key, locale, content) VALUES ('%s', '%s', '%s') ON CONFLICT (key, locale) DO UPDATE SET content = EXCLUDED.content;\n", k.Key, lang, escapedContent))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("COMMIT;\n")
+	return sb.String(), nil
+}
+
+// Helper to ensure agents implement the interface
+var _ agent.AgentInstance = &KeyExtractor{}
+var _ agent.AgentInstance = &TranslationGenerator{}
+var _ agent.AgentInstance = &TranslationEnhancer{}
+var _ agent.AgentInstance = &SQLGenerator{}

--- a/internal/cli/i18n/agents_test.go
+++ b/internal/cli/i18n/agents_test.go
@@ -1,0 +1,165 @@
+package i18n
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestKeyExtractor_Execute(t *testing.T) {
+	tests := []struct {
+		name     string
+		diff     string
+		expected []string
+	}{
+		{
+			name: "Basic t function",
+			diff: `
++ console.log(t('hello.world'));
++ const x = t("another.key");
+`,
+			expected: []string{"hello.world", "another.key"},
+		},
+		{
+			name: "React components",
+			diff: `
++ <T key="component.key" />
++ <T keyName="trans.key" />
+`,
+			expected: []string{"component.key", "trans.key"},
+		},
+		{
+			name: "Vue/Other patterns",
+			diff: `
++ $t('vue.key')
++ i18n.t('lib.key')
+`,
+			expected: []string{"vue.key", "lib.key"},
+		},
+		{
+			name: "Ignore unchanged lines",
+			diff: `
+  t('ignored.key')
++ t('included.key')
+- t('deleted.key')
+`,
+			expected: []string{"included.key"},
+		},
+		{
+			name: "Complex context",
+			diff: `
++ if (true) { return t('nested.key'); }
++ <div title={t('attr.key')}></div>
+`,
+			expected: []string{"nested.key", "attr.key"},
+		},
+		{
+			name: "Duplicate keys",
+			diff: `
++ t('dup.key')
++ t('dup.key')
+`,
+			expected: []string{"dup.key"},
+		},
+		{
+			name: "Quotes in keys",
+			diff: `
++ t("It's a key")
++ t('Say "Hello"')
+`,
+			expected: []string{"It's a key", `Say "Hello"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor := NewKeyExtractor(tt.diff)
+			result, err := extractor.Execute(nil)
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			var keys []I18nKey
+			if err := json.Unmarshal([]byte(result), &keys); err != nil {
+				t.Fatalf("Failed to unmarshal result: %v", err)
+			}
+
+			// Create a map for easier checking
+			keyMap := make(map[string]bool)
+			for _, k := range keys {
+				keyMap[k.Key] = true
+			}
+
+			for _, expectedKey := range tt.expected {
+				if !keyMap[expectedKey] {
+					t.Errorf("Expected key %q not found", expectedKey)
+				}
+			}
+
+			if len(keys) != len(tt.expected) {
+				t.Errorf("Expected %d keys, got %d", len(tt.expected), len(keys))
+			}
+		})
+	}
+}
+
+func TestSQLGenerator_Execute(t *testing.T) {
+	// Mock input data from TranslationEnhancer
+	inputData := TranslationData{
+		Keys: []I18nKey{
+			{
+				Key: "test.key",
+				Translations: map[string]string{
+					"en": "Hello World",
+					"de": "Hallo Welt",
+				},
+			},
+			{
+				Key: "escape.key",
+				Translations: map[string]string{
+					"en": "It's a test",
+					"fr": "C'est un test",
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(inputData)
+	if err != nil {
+		t.Fatalf("Failed to marshal input data: %v", err)
+	}
+
+	generator := NewSQLGenerator()
+	input := map[string]string{
+		"translation_enhancer": string(jsonData),
+	}
+
+	result, err := generator.Execute(input)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Verify SQL content
+	if !strings.Contains(result, "BEGIN;") {
+		t.Error("SQL should start transaction")
+	}
+	if !strings.Contains(result, "COMMIT;") {
+		t.Error("SQL should commit transaction")
+	}
+
+	// Check first key
+	if !strings.Contains(result, "VALUES ('test.key', 'en', 'Hello World')") {
+		t.Error("Missing English translation for test.key")
+	}
+	if !strings.Contains(result, "VALUES ('test.key', 'de', 'Hallo Welt')") {
+		t.Error("Missing German translation for test.key")
+	}
+
+	// Check escaping
+	if !strings.Contains(result, "VALUES ('escape.key', 'en', 'It''s a test')") {
+		t.Error("Single quote not escaped correctly in English")
+	}
+	if !strings.Contains(result, "VALUES ('escape.key', 'fr', 'C''est un test')") {
+		t.Error("Single quote not escaped correctly in French")
+	}
+}

--- a/internal/cli/i18n/command.go
+++ b/internal/cli/i18n/command.go
@@ -1,0 +1,244 @@
+package i18n
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MagdielCAS/magi-cli/pkg/agent"
+	"github.com/MagdielCAS/magi-cli/pkg/git"
+	"github.com/MagdielCAS/magi-cli/pkg/llm"
+	"github.com/MagdielCAS/magi-cli/pkg/shared"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	originBranch string
+	maxTokens    int
+	textFormat   bool
+	autoConfirm  bool
+	tolgeeOutput bool
+	languages    []string
+	outputFile   string
+)
+
+var i18nCmd = &cobra.Command{
+	Use:   "i18n",
+	Short: "AI-powered i18n translation management",
+	Long: `Automates the extraction and translation of i18n keys from code changes.
+It compares the current branch with an origin branch to find new keys,
+then uses AI agents to generate translations in specified languages.`,
+	RunE: runI18n,
+}
+
+func I18nCmd() *cobra.Command {
+	i18nCmd.Flags().StringVar(&originBranch, "origin", "main", "Origin branch to compare against")
+	i18nCmd.Flags().IntVar(&maxTokens, "max-tokens", 1000, "Max tokens for AI response")
+	i18nCmd.Flags().BoolVar(&textFormat, "text-format", false, "Use text format instead of JSON schema")
+	i18nCmd.Flags().BoolVar(&autoConfirm, "yes", false, "Auto-confirm all prompts")
+	i18nCmd.Flags().BoolVar(&tolgeeOutput, "tolgee", false, "Generate Tolgee-compatible output files")
+	i18nCmd.Flags().StringSliceVar(&languages, "languages", []string{"en", "de"}, "Target languages for translation")
+	i18nCmd.Flags().StringVarP(&outputFile, "output", "o", "i18n_translations.json", "Output file for translations")
+
+	return i18nCmd
+}
+
+func runI18n(cmd *cobra.Command, args []string) error {
+	pterm.DefaultSection.Println("Running AI-Powered I18n Extraction")
+
+	// 1. Git Integration
+	ctx := cmd.Context()
+	if err := git.EnsureGitRepo(ctx); err != nil {
+		return err
+	}
+
+	currentBranch, err := git.CurrentBranchName(ctx)
+	if err != nil {
+		return err
+	}
+
+	pterm.Info.Printf("Comparing branch '%s' with origin '%s'...\n", currentBranch, originBranch)
+
+	// Using 3 dots ... finds the merge base.
+	diffOutput, err := git.RunGit(ctx, "diff", "-U0", "--no-color", fmt.Sprintf("origin/%s...%s", originBranch, currentBranch))
+	if err != nil {
+		// Try without origin prefix if it fails, maybe it's a local branch comparison
+		diffOutput, err = git.RunGit(ctx, "diff", "-U0", "--no-color", fmt.Sprintf("%s...%s", originBranch, currentBranch))
+		if err != nil {
+			return fmt.Errorf("failed to get git diff: %w", err)
+		}
+	}
+
+	if diffOutput == "" {
+		pterm.Warning.Println("No changes detected between branches.")
+		return nil
+	}
+
+	// 2. Initialize Agents
+	pool := agent.NewAgentPool()
+
+	// Key Extractor
+	keyExtractor := NewKeyExtractor(diffOutput)
+	pool.WithAgent(keyExtractor)
+
+	// Translation Generator
+	runtimeCtx, err := shared.BuildRuntimeContext()
+	if err != nil {
+		return fmt.Errorf("failed to build runtime context: %w", err)
+	}
+
+	llmService, err := llm.NewServiceBuilder(runtimeCtx).UseHeavyModel().Build()
+	if err != nil {
+		return fmt.Errorf("failed to build LLM service: %w", err)
+	}
+
+	translationGenerator := NewTranslationGenerator(llmService)
+	pool.WithAgent(translationGenerator)
+
+	// Translation Enhancer
+	pool.WithAgent(NewTranslationEnhancer(llmService))
+
+	// SQL Generator
+	pool.WithAgent(NewSQLGenerator())
+
+	// Execute Agents
+	spinner, _ := pterm.DefaultSpinner.Start("Analyzing code, extracting keys, and generating translations...")
+	results, err := pool.ExecuteAgents(nil)
+	if err != nil {
+		spinner.Fail("Agent execution failed: " + err.Error())
+		return err
+	}
+	spinner.Success("Analysis complete!")
+
+	// 3. Process Results
+	// We are interested in the final output from TranslationEnhancer (for JSON/Tolgee) and SQLGenerator (for SQL)
+
+	// Check if keys were found
+	keysJSON := results["key_extractor"]
+	var keys []I18nKey
+	if err := json.Unmarshal([]byte(keysJSON), &keys); err != nil {
+		return fmt.Errorf("failed to parse extracted keys: %w", err)
+	}
+
+	if len(keys) == 0 {
+		pterm.Info.Println("No new i18n keys found.")
+		return nil
+	}
+
+	pterm.Success.Printf("Found %d new keys.\n", len(keys))
+
+	// Get Enhanced Translations
+	translationsJSON := results["translation_enhancer"]
+	var translationData TranslationData
+	if err := json.Unmarshal([]byte(translationsJSON), &translationData); err != nil {
+		// Try to unmarshal as array of keys directly
+		var keysWithTrans []I18nKey
+		if err2 := json.Unmarshal([]byte(translationsJSON), &keysWithTrans); err2 == nil {
+			translationData = TranslationData{Keys: keysWithTrans}
+		} else {
+			pterm.Warning.Printf("Failed to parse translations JSON: %v\n", err)
+			return nil
+		}
+	}
+
+	// Display Results
+	pterm.DefaultSection.Println("Generated Translations")
+	for _, k := range translationData.Keys {
+		pterm.Println(pterm.Cyan(k.Key))
+		for lang, trans := range k.Translations {
+			pterm.Printf("  %s: %s\n", strings.ToUpper(lang), trans)
+		}
+		pterm.Println()
+	}
+
+	// Output Handling
+	if !autoConfirm {
+		confirmed, _ := pterm.DefaultInteractiveConfirm.Show("Save these translations?")
+		if !confirmed {
+			pterm.Info.Println("Aborted.")
+			return nil
+		}
+	}
+
+	// Save JSON
+	if err := createTranslationFile(&translationData); err != nil {
+		pterm.Error.Println("Failed to save JSON file:", err)
+	}
+
+	// Save SQL
+	sqlScript := results["sql_generator"]
+	if err := createSQLFile(sqlScript); err != nil {
+		pterm.Error.Println("Failed to save SQL file:", err)
+	}
+
+	// Save Tolgee
+	if tolgeeOutput {
+		if err := createTolgeeFiles(&translationData); err != nil {
+			pterm.Error.Println("Failed to save Tolgee files:", err)
+		}
+	}
+
+	return nil
+}
+
+func createTranslationFile(data *TranslationData) error {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	filename := outputFile
+	if filename == "" {
+		filename = "i18n_translations.json"
+	}
+	if err := os.WriteFile(filename, jsonData, 0644); err != nil {
+		return err
+	}
+	pterm.Success.Println("Saved translations to " + filename)
+	return nil
+}
+
+func createSQLFile(content string) error {
+	filename := "i18n_insert.sql"
+	if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+		return err
+	}
+	pterm.Success.Println("Saved SQL script to " + filename)
+	return nil
+}
+
+func createTolgeeFiles(data *TranslationData) error {
+	// Convert to map[lang]map[key]value
+	langMaps := make(map[string]map[string]string)
+
+	for _, k := range data.Keys {
+		for lang, trans := range k.Translations {
+			if _, ok := langMaps[lang]; !ok {
+				langMaps[lang] = make(map[string]string)
+			}
+			langMaps[lang][k.Key] = trans
+		}
+	}
+
+	var savedFiles []string
+	for lang, content := range langMaps {
+		filename := fmt.Sprintf("%s.json", lang)
+		if err := writeJSONFile(filename, content); err != nil {
+			return err
+		}
+		savedFiles = append(savedFiles, filename)
+	}
+
+	pterm.Success.Printf("Saved Tolgee files (%s)\n", strings.Join(savedFiles, ", "))
+	return nil
+}
+
+func writeJSONFile(filename string, data interface{}) error {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, jsonData, 0644)
+}

--- a/internal/cli/i18n/command.go
+++ b/internal/cli/i18n/command.go
@@ -3,8 +3,10 @@ package i18n
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/MagdielCAS/magi-cli/pkg/agent"
 	"github.com/MagdielCAS/magi-cli/pkg/git"
@@ -89,7 +91,15 @@ func runI18n(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to build runtime context: %w", err)
 	}
 
-	llmService, err := llm.NewServiceBuilder(runtimeCtx).UseHeavyModel().Build()
+	// Create a custom HTTP client with a longer timeout for heavy translation tasks
+	customClient := &http.Client{
+		Timeout: 5 * time.Minute,
+	}
+
+	llmService, err := llm.NewServiceBuilder(runtimeCtx).
+		UseHeavyModel().
+		WithHTTPClient(customClient).
+		Build()
 	if err != nil {
 		return fmt.Errorf("failed to build LLM service: %w", err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to magi-cli! 🎉

Please provide a clear and concise description of the changes in this pull request.
If applicable, link to any related issues.
-->

**Description**

Introduces magi i18n command using agent pipeline to extract i18n keys from git branch diffs, translate via LLM, enhance, and output JSON/SQL/Tolgee formats. Follows Cobra patterns and uses RuntimeContext/LLM pkg.

Security impacts: Git diffs (potentially containing secrets/code) sent unredacted to external LLM (data leaves machine); no user warnings/redaction. Custom HTTP client bypasses shared TLS/timeout policies. No file path validation for outputs (arbitrary overwrites possible).

Testing impacts: No tests added; requires integration/E2E tests for pipeline, LLM failures/parsing, git diff variations, output formats, and security (no secrets in requests).

Documentation impacts: Missing examples/security callouts in docs/docs.md; no updates to docs/commands.md, docs/getting-started.md, docs/configuration.md for flags; no 'Since' tags.

**Related Issues**

- None

**Checklist**

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/MagdielCAS/magi-cli/blob/main/docs/CONTRIBUTING.md) guidelines.
- [x] My code follows the project's style and formatting.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the documentation to reflect my changes.
