### PR TITLE
feat(crypto): add salt, keyfile, keypair subcommands

### DIFF
--- a/.github/workflows/internal-ci.yml
+++ b/.github/workflows/internal-ci.yml
@@ -2,6 +2,9 @@ name: update-docs
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ magi-cli is a command-line interface tool designed to enhance programmer product
 - Project scaffolding
 - Documentation assistance
 - Code review suggestions
+- Cryptographic utilities
+- SSH connection management
+- AI-powered i18n translation
 - And more...
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ magi-cli is a command-line interface tool designed to enhance programmer product
 - Project scaffolding
 - Documentation assistance
 - Code review suggestions
-- Cryptographic utilities
-- SSH connection management
-- AI-powered i18n translation
 - And more...
 
 ## Installation

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	cliCommit "github.com/MagdielCAS/magi-cli/internal/cli/commit"
 	"github.com/MagdielCAS/magi-cli/internal/cli/config"
+	"github.com/MagdielCAS/magi-cli/internal/cli/crypto"
 	"github.com/MagdielCAS/magi-cli/internal/cli/i18n"
 	"github.com/MagdielCAS/magi-cli/internal/cli/pr"
 	"github.com/MagdielCAS/magi-cli/internal/cli/push"
@@ -218,6 +219,7 @@ func init() {
 	rootCmd.AddCommand(pr.PRCmd())
 	rootCmd.AddCommand(cliCommit.CommitCmd())
 	rootCmd.AddCommand(config.ConfigCmd())
+	rootCmd.AddCommand(crypto.CryptoCmd())
 	rootCmd.AddCommand(ssh.SSHCmd())
 	rootCmd.AddCommand(i18n.I18nCmd())
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -176,6 +176,101 @@ Security callout:
 - Documents outbound data (diff + AGENTS guidelines) in the command help text so users know exactly what leaves their machine.
 - Respects configured timeouts for analysis and writing phases (see `magi config`).
 
+### ssh _(Since v0.4.0)_
+
+Manage and connect to SSH servers.
+
+A comprehensive SSH connection management system.
+Allows you to add, connect, list, and remove SSH connections with ease.
+
+```bash
+magi ssh [command]
+```
+
+**Subcommands:**
+
+- `add`: Add a new SSH connection
+- `connect`: Connect to a saved SSH server
+- `list`: List all saved SSH connections
+- `remove`: Remove a saved SSH connection
+
+**Examples:**
+
+```bash
+# Add a new connection
+magi ssh add
+
+# Connect to a saved server
+magi ssh connect my-server
+
+# List all connections
+magi ssh list
+
+# Remove a connection
+magi ssh remove my-server
+```
+
+### i18n _(Since v0.5.0)_
+
+AI-powered i18n translation management.
+
+Automates the extraction and translation of i18n keys from code changes.
+It compares the current branch with an origin branch to find new keys,
+then uses AI agents to generate translations in specified languages.
+
+```bash
+magi i18n [flags]
+```
+
+**Flags:**
+- `--origin <branch>`: Origin branch to compare against (default "main")
+- `--max-tokens <int>`: Max tokens for AI response (default 1000)
+- `--text-format`: Use text format instead of JSON schema
+- `--yes`: Auto-confirm all prompts
+- `--tolgee`: Generate Tolgee-compatible output files
+- `--languages <lang1,lang2>`: Target languages for translation (default "en,de")
+- `--output <file>`: Output file for translations (default "i18n_translations.json")
+
+**Examples:**
+
+```bash
+# Run i18n extraction and translation against main branch
+magi i18n
+
+# Specify target languages and output file
+magi i18n --languages en,es,fr --output translations.json
+
+# Generate Tolgee-compatible files
+magi i18n --tolgee
+```
+
+### crypto _(Since v0.5.1)_
+
+Cryptographic utilities for generating secure keys, salts, and keyfiles.
+
+```bash
+magi crypto [command]
+```
+
+**Subcommands:**
+
+- `salt`: Generate a random salt key
+- `keyfile`: Generate a MongoDB keyfile
+- `keypair`: Generate a public/private key pair
+
+**Examples:**
+
+```bash
+# Generate a 32-byte salt
+magi crypto salt
+
+# Generate a MongoDB keyfile non-interactively
+magi crypto keyfile --yes
+
+# Generate an RSA key pair
+magi crypto keypair --algorithm rsa
+```
+
 ## Additional Commands
 
 [More commands will be added as they are implemented]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -248,6 +248,8 @@ magi i18n --tolgee
 
 Cryptographic utilities for generating secure keys, salts, and keyfiles.
 
+**Security:** These commands run locally and perform no network calls. Generated materials are stored on disk with restrictive permissions (0400 for keyfiles, 0600 for private keys, 0644 for public keys); review file ownership before use.
+
 ```bash
 magi crypto [command]
 ```
@@ -264,7 +266,7 @@ magi crypto [command]
 # Generate a 32-byte salt
 magi crypto salt
 
-# Generate a MongoDB keyfile non-interactively
+# Generate a MongoDB keyfile non-interactively (1024-character base64 output)
 magi crypto keyfile --yes
 
 # Generate an RSA key pair

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -47,6 +47,7 @@ Run 'magi [command] --help' for more information on a specific command.
 |`magi commit`|Generate a conventional commit message with AI and create the commit|
 |`magi completion`|Generate completion script|
 |`magi config`|Manages the magi configuration|
+|`magi crypto`|Cryptographic utilities|
 |`magi help`|Help about any command|
 |`magi i18n`|AI-powered i18n translation management|
 |`magi pr`|Review local commits with AI agents and open a GitHub pull request|
@@ -282,6 +283,156 @@ Examples:
 
 Run 'magi config set --help' for more information on a specific command.
 ```
+# ... crypto
+`magi crypto`
+
+## Usage
+> Cryptographic utilities
+
+magi crypto
+
+## Description
+
+```
+Cryptographic utilities for generating secure keys, salts, and keyfiles.
+
+Available subcommands:
+  salt        Generate a random salt key
+  keyfile     Generate a MongoDB keyfile
+  keypair     Generate a public/private key pair
+
+Usage:
+  magi crypto [command]
+
+Examples:
+  # Default behavior (generates a salt)
+  magi crypto
+
+  # Generate a salt
+  magi crypto salt
+
+  # Generate a MongoDB keyfile
+  magi crypto keyfile
+
+  # Generate a key pair
+  magi crypto keypair
+
+Run 'magi crypto [command] --help' for more information on a specific command.
+```
+
+## Commands
+|Command|Usage|
+|-------|-----|
+|`magi crypto keyfile`|Generate a MongoDB keyfile|
+|`magi crypto keypair`|Generate a public/private key pair|
+|`magi crypto salt`|Generate a random salt key|
+# ... crypto keyfile
+`magi crypto keyfile`
+
+## Usage
+> Generate a MongoDB keyfile
+
+magi crypto keyfile
+
+## Description
+
+```
+Generate a MongoDB keyfile for replica set authentication.
+The keyfile contains 1024 bytes of random data, base64 encoded.
+File permissions are set to 0400 (read-only for owner) for security.
+```
+## Examples
+
+```bash
+  # Generate keyfile with default settings (prompts for confirmation)
+  magi crypto keyfile
+
+  # Generate keyfile non-interactively
+  magi crypto keyfile --yes
+
+  # Generate keyfile with custom name and path
+  magi crypto keyfile --filename my-key --path ./secrets --yes
+
+  # Interactive mode
+  magi crypto keyfile --interactive
+```
+
+## Flags
+|Flag|Usage|
+|----|-----|
+|`-f, --filename string`|Filename (default "keyfile")|
+|`-i, --interactive`|Interactive mode|
+|`-p, --path string`|Directory path (default ".")|
+|`-y, --yes`|Skip prompts|
+# ... crypto keypair
+`magi crypto keypair`
+
+## Usage
+> Generate a public/private key pair
+
+magi crypto keypair
+
+## Description
+
+```
+Generate a public/private key pair using RSA, ECDSA, or Ed25519 algorithms.
+Keys are saved in PEM format.
+Private keys are saved with 0600 permissions.
+Public keys are saved with 0644 permissions.
+```
+## Examples
+
+```bash
+  # Generate RSA key pair (default)
+  magi crypto keypair
+
+  # Generate ECDSA key pair
+  magi crypto keypair --algorithm ecdsa
+
+  # Generate Ed25519 key pair
+  magi crypto keypair --algorithm ed25519
+
+  # Generate only public key from existing private key
+  magi crypto keypair --public --private-key-path ./private.pem
+```
+
+## Flags
+|Flag|Usage|
+|----|-----|
+|`-a, --algorithm string`|Key algorithm (rsa, ecdsa, ed25519) (default "rsa")|
+|`-f, --filename string`|Key filename (no extension) (default "key")|
+|`-p, --path string`|Output directory (default ".")|
+|`--private`|Generate only private key|
+|`--private-key-path string`|Existing private key path (for public key generation)|
+|`--public`|Generate only public key|
+|`-y, --yes`|Skip prompts|
+# ... crypto salt
+`magi crypto salt`
+
+## Usage
+> Generate a random salt key
+
+magi crypto salt
+
+## Description
+
+```
+Generate a random salt key of a specified length.
+```
+## Examples
+
+```bash
+  # Generate a 32-byte salt (default)
+  magi crypto salt
+
+  # Generate a 64-byte salt
+  magi crypto salt --length 64
+```
+
+## Flags
+|Flag|Usage|
+|----|-----|
+|`-l, --length int`|Salt length (default 32)|
 # ... help
 `magi help`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,9 @@ Here are some common commands to get you started:
 # Get help
 magi-cli --help
 
+# Generate a local salt (no network calls)
+magi crypto salt --length 32
+
 # Generate code documentation
 magi-cli doc generate ./path/to/file
 

--- a/internal/cli/crypto/command.go
+++ b/internal/cli/crypto/command.go
@@ -1,0 +1,47 @@
+package crypto
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cryptoCmd = &cobra.Command{
+	Use:   "crypto",
+	Short: "Cryptographic utilities",
+	Long: `Cryptographic utilities for generating secure keys, salts, and keyfiles.
+
+Available subcommands:
+  salt        Generate a random salt key
+  keyfile     Generate a MongoDB keyfile
+  keypair     Generate a public/private key pair
+
+Usage:
+  magi crypto [command]
+
+Examples:
+  # Default behavior (generates a salt)
+  magi crypto
+
+  # Generate a salt
+  magi crypto salt
+
+  # Generate a MongoDB keyfile
+  magi crypto keyfile
+
+  # Generate a key pair
+  magi crypto keypair
+
+Run 'magi crypto [command] --help' for more information on a specific command.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			// Default to salt
+			SaltCmd.Run(cmd, args)
+		}
+	},
+}
+
+func CryptoCmd() *cobra.Command {
+	cryptoCmd.AddCommand(SaltCmd)
+	cryptoCmd.AddCommand(KeyfileCmd)
+	cryptoCmd.AddCommand(KeypairCmd)
+	return cryptoCmd
+}

--- a/internal/cli/crypto/keyfile.go
+++ b/internal/cli/crypto/keyfile.go
@@ -22,7 +22,7 @@ var KeyfileCmd = &cobra.Command{
 	Use:   "keyfile",
 	Short: "Generate a MongoDB keyfile",
 	Long: `Generate a MongoDB keyfile for replica set authentication.
-The keyfile contains 1024 bytes of random data, base64 encoded.
+The keyfile contains 768 bytes of random data (1024 base64 characters), base64 encoded.
 File permissions are set to 0400 (read-only for owner) for security.`,
 	Example: `  # Generate keyfile with default settings (prompts for confirmation)
   magi crypto keyfile
@@ -90,8 +90,8 @@ func generateFileWithDirCheck(path, filename string) {
 		}
 	}
 
-	// Generate key
-	key := make([]byte, 1024)
+	// Generate key (MongoDB limits keyfiles to 1024 characters, so we use 768 raw bytes)
+	key := make([]byte, 768)
 	_, err := rand.Read(key)
 	if err != nil {
 		pterm.Error.Printf("Failed to generate key: %v\n", err)

--- a/internal/cli/crypto/keyfile.go
+++ b/internal/cli/crypto/keyfile.go
@@ -1,0 +1,110 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyfileYes         bool
+	keyfileFilename    string
+	keyfilePath        string
+	keyfileInteractive bool
+)
+
+var KeyfileCmd = &cobra.Command{
+	Use:   "keyfile",
+	Short: "Generate a MongoDB keyfile",
+	Long: `Generate a MongoDB keyfile for replica set authentication.
+The keyfile contains 1024 bytes of random data, base64 encoded.
+File permissions are set to 0400 (read-only for owner) for security.`,
+	Example: `  # Generate keyfile with default settings (prompts for confirmation)
+  magi crypto keyfile
+
+  # Generate keyfile non-interactively
+  magi crypto keyfile --yes
+
+  # Generate keyfile with custom name and path
+  magi crypto keyfile --filename my-key --path ./secrets --yes
+
+  # Interactive mode
+  magi crypto keyfile --interactive`,
+	Run: runGenerateKeyfile,
+}
+
+func init() {
+	KeyfileCmd.Flags().BoolVarP(&keyfileYes, "yes", "y", false, "Skip prompts")
+	KeyfileCmd.Flags().StringVarP(&keyfileFilename, "filename", "f", "keyfile", "Filename")
+	KeyfileCmd.Flags().StringVarP(&keyfilePath, "path", "p", ".", "Directory path")
+	KeyfileCmd.Flags().BoolVarP(&keyfileInteractive, "interactive", "i", false, "Interactive mode")
+}
+
+func runGenerateKeyfile(cmd *cobra.Command, args []string) {
+	if keyfileInteractive && keyfileYes {
+		pterm.Error.Println("Cannot use both --interactive and --yes flags")
+		return
+	}
+
+	if keyfileInteractive {
+		var err error
+		keyfileFilename, err = pterm.DefaultInteractiveTextInput.WithDefaultText(keyfileFilename).Show("Enter filename")
+		if err != nil {
+			return
+		}
+		keyfilePath, err = pterm.DefaultInteractiveTextInput.WithDefaultText(keyfilePath).Show("Enter directory path")
+		if err != nil {
+			return
+		}
+	} else if !keyfileYes {
+		confirm, _ := pterm.DefaultInteractiveConfirm.WithDefaultValue(true).Show("Generate MongoDB keyfile?")
+		if !confirm {
+			pterm.Warning.Println("Operation cancelled")
+			return
+		}
+	}
+
+	generateFileWithDirCheck(keyfilePath, keyfileFilename)
+}
+
+func generateFileWithDirCheck(path, filename string) {
+	fullPath := filepath.Join(path, filename)
+
+	// Ensure directory exists
+	if err := os.MkdirAll(path, 0755); err != nil {
+		pterm.Error.Printf("Failed to create directory: %v\n", err)
+		return
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(fullPath); err == nil {
+		overwrite, _ := pterm.DefaultInteractiveConfirm.WithDefaultValue(false).Show(fmt.Sprintf("File %s already exists. Overwrite?", fullPath))
+		if !overwrite {
+			pterm.Warning.Println("Operation cancelled")
+			return
+		}
+	}
+
+	// Generate key
+	key := make([]byte, 1024)
+	_, err := rand.Read(key)
+	if err != nil {
+		pterm.Error.Printf("Failed to generate key: %v\n", err)
+		return
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(key)
+
+	// Write file
+	if err := os.WriteFile(fullPath, []byte(encoded), 0400); err != nil {
+		pterm.Error.Printf("Failed to write keyfile: %v\n", err)
+		return
+	}
+
+	pterm.Success.Printf("Keyfile generated at %s\n", fullPath)
+}

--- a/internal/cli/crypto/keyfile_test.go
+++ b/internal/cli/crypto/keyfile_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,9 +32,10 @@ func TestGenerateFileWithDirCheck(t *testing.T) {
 	info, err := os.Stat(fullPath)
 	assert.NoError(t, err)
 
-	// Verify permissions (0400)
-	// Note: On Windows permissions might work differently, but this is for Mac/Linux
-	assert.Equal(t, os.FileMode(0400), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		// Verify permissions (0400)
+		assert.Equal(t, os.FileMode(0400), info.Mode().Perm())
+	}
 
 	// Verify content
 	content, err := os.ReadFile(fullPath)
@@ -43,6 +45,6 @@ func TestGenerateFileWithDirCheck(t *testing.T) {
 	decoded, err := base64.StdEncoding.DecodeString(string(content))
 	assert.NoError(t, err)
 
-	// Should be 1024 bytes
-	assert.Equal(t, 1024, len(decoded))
+	// Should be 768 bytes to stay under MongoDB's 1024-character limit
+	assert.Equal(t, 768, len(decoded))
 }

--- a/internal/cli/crypto/keyfile_test.go
+++ b/internal/cli/crypto/keyfile_test.go
@@ -1,0 +1,48 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyfileCmd(t *testing.T) {
+	cmd := KeyfileCmd
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "keyfile", cmd.Use)
+}
+
+func TestGenerateFileWithDirCheck(t *testing.T) {
+	// Create temp dir
+	tmpDir, err := os.MkdirTemp("", "magi-crypto-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	filename := "test-keyfile"
+	fullPath := filepath.Join(tmpDir, filename)
+
+	// Generate keyfile
+	generateFileWithDirCheck(tmpDir, filename)
+
+	// Verify file exists
+	info, err := os.Stat(fullPath)
+	assert.NoError(t, err)
+
+	// Verify permissions (0400)
+	// Note: On Windows permissions might work differently, but this is for Mac/Linux
+	assert.Equal(t, os.FileMode(0400), info.Mode().Perm())
+
+	// Verify content
+	content, err := os.ReadFile(fullPath)
+	assert.NoError(t, err)
+
+	// Should be base64 encoded
+	decoded, err := base64.StdEncoding.DecodeString(string(content))
+	assert.NoError(t, err)
+
+	// Should be 1024 bytes
+	assert.Equal(t, 1024, len(decoded))
+}

--- a/internal/cli/crypto/keypair.go
+++ b/internal/cli/crypto/keypair.go
@@ -1,0 +1,254 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	keypairFilename        string
+	keypairPath            string
+	keypairAlgorithm       string
+	keypairYes             bool
+	keypairGeneratePublic  bool
+	keypairGeneratePrivate bool
+	keypairPrivateKeyPath  string
+)
+
+var KeypairCmd = &cobra.Command{
+	Use:   "keypair",
+	Short: "Generate a public/private key pair",
+	Long: `Generate a public/private key pair using RSA, ECDSA, or Ed25519 algorithms.
+Keys are saved in PEM format.
+Private keys are saved with 0600 permissions.
+Public keys are saved with 0644 permissions.`,
+	Example: `  # Generate RSA key pair (default)
+  magi crypto keypair
+
+  # Generate ECDSA key pair
+  magi crypto keypair --algorithm ecdsa
+
+  # Generate Ed25519 key pair
+  magi crypto keypair --algorithm ed25519
+
+  # Generate only public key from existing private key
+  magi crypto keypair --public --private-key-path ./private.pem`,
+	Run: runGenerateKeypair,
+}
+
+func init() {
+	KeypairCmd.Flags().StringVarP(&keypairFilename, "filename", "f", "key", "Key filename (no extension)")
+	KeypairCmd.Flags().StringVarP(&keypairPath, "path", "p", ".", "Output directory")
+	KeypairCmd.Flags().StringVarP(&keypairAlgorithm, "algorithm", "a", "rsa", "Key algorithm (rsa, ecdsa, ed25519)")
+	KeypairCmd.Flags().BoolVarP(&keypairYes, "yes", "y", false, "Skip prompts")
+	KeypairCmd.Flags().BoolVar(&keypairGeneratePublic, "public", false, "Generate only public key")
+	KeypairCmd.Flags().BoolVar(&keypairGeneratePrivate, "private", false, "Generate only private key")
+	KeypairCmd.Flags().StringVar(&keypairPrivateKeyPath, "private-key-path", "", "Existing private key path (for public key generation)")
+}
+
+func runGenerateKeypair(cmd *cobra.Command, args []string) {
+	// Validate flags
+	if keypairGeneratePublic && keypairGeneratePrivate {
+		pterm.Error.Println("Cannot specify both --public and --private")
+		return
+	}
+
+	if keypairGeneratePublic && keypairPrivateKeyPath == "" {
+		pterm.Error.Println("Must specify --private-key-path when using --public")
+		return
+	}
+
+	// Interactive prompts if not skipped
+	if !keypairYes && !keypairGeneratePublic {
+		var err error
+		keypairAlgorithm, err = pterm.DefaultInteractiveSelect.
+			WithOptions([]string{"rsa", "ecdsa", "ed25519"}).
+			WithDefaultOption(keypairAlgorithm).
+			Show("Select key algorithm")
+		if err != nil {
+			return
+		}
+
+		keypairFilename, err = pterm.DefaultInteractiveTextInput.
+			WithDefaultText(keypairFilename).
+			Show("Enter key filename (no extension)")
+		if err != nil {
+			return
+		}
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(keypairPath, 0755); err != nil {
+		pterm.Error.Printf("Failed to create directory: %v\n", err)
+		return
+	}
+
+	privateKeyPath := filepath.Join(keypairPath, keypairFilename+".pem")
+	publicKeyPath := filepath.Join(keypairPath, keypairFilename+".pub")
+
+	if keypairGeneratePublic {
+		// Generate public key from existing private key
+		if err := generatePublicKeyFromPrivate(keypairPrivateKeyPath, publicKeyPath); err != nil {
+			pterm.Error.Printf("Failed to generate public key: %v\n", err)
+			return
+		}
+		pterm.Success.Printf("Public key generated at %s\n", publicKeyPath)
+		return
+	}
+
+	// Generate new key pair
+	priv, pub, err := generateKeys(keypairAlgorithm)
+	if err != nil {
+		pterm.Error.Printf("Failed to generate keys: %v\n", err)
+		return
+	}
+
+	// Save private key
+	if !keypairGeneratePublic {
+		if err := savePrivateKey(priv, privateKeyPath); err != nil {
+			pterm.Error.Printf("Failed to save private key: %v\n", err)
+			return
+		}
+		pterm.Success.Printf("Private key generated at %s\n", privateKeyPath)
+	}
+
+	// Save public key
+	if !keypairGeneratePrivate {
+		if err := savePublicKey(pub, publicKeyPath); err != nil {
+			pterm.Error.Printf("Failed to save public key: %v\n", err)
+			return
+		}
+		pterm.Success.Printf("Public key generated at %s\n", publicKeyPath)
+	}
+}
+
+func generateKeys(algo string) (interface{}, interface{}, error) {
+	switch strings.ToLower(algo) {
+	case "rsa":
+		priv, err := rsa.GenerateKey(rand.Reader, 4096)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, &priv.PublicKey, nil
+	case "ecdsa":
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, &priv.PublicKey, nil
+	case "ed25519":
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, pub, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported algorithm: %s", algo)
+	}
+}
+
+func savePrivateKey(key interface{}, path string) error {
+	var bytes []byte
+	var err error
+	var block *pem.Block
+
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		bytes = x509.MarshalPKCS1PrivateKey(k)
+		block = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: bytes}
+	case *ecdsa.PrivateKey:
+		bytes, err = x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return err
+		}
+		block = &pem.Block{Type: "EC PRIVATE KEY", Bytes: bytes}
+	case ed25519.PrivateKey:
+		bytes, err = x509.MarshalPKCS8PrivateKey(k)
+		if err != nil {
+			return err
+		}
+		block = &pem.Block{Type: "PRIVATE KEY", Bytes: bytes}
+	default:
+		return fmt.Errorf("unsupported private key type")
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return pem.Encode(file, block)
+}
+
+func savePublicKey(key interface{}, path string) error {
+	bytes, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return err
+	}
+
+	block := &pem.Block{Type: "PUBLIC KEY", Bytes: bytes}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return pem.Encode(file, block)
+}
+
+func generatePublicKeyFromPrivate(privatePath, publicPath string) error {
+	data, err := os.ReadFile(privatePath)
+	if err != nil {
+		return err
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return fmt.Errorf("failed to decode PEM block containing private key")
+	}
+
+	var pub interface{}
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		priv, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return err
+		}
+		pub = &priv.PublicKey
+	case "EC PRIVATE KEY":
+		priv, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return err
+		}
+		pub = &priv.PublicKey
+	case "PRIVATE KEY":
+		priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return err
+		}
+		switch k := priv.(type) {
+		case ed25519.PrivateKey:
+			pub = k.Public()
+		default:
+			return fmt.Errorf("unsupported private key type in PKCS8")
+		}
+	default:
+		return fmt.Errorf("unsupported private key type: %s", block.Type)
+	}
+
+	return savePublicKey(pub, publicPath)
+}

--- a/internal/cli/crypto/keypair_test.go
+++ b/internal/cli/crypto/keypair_test.go
@@ -1,0 +1,120 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeypairCmd(t *testing.T) {
+	cmd := KeypairCmd
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "keypair", cmd.Use)
+}
+
+func TestGenerateKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		algo string
+	}{
+		{"RSA", "rsa"},
+		{"ECDSA", "ecdsa"},
+		{"Ed25519", "ed25519"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priv, pub, err := generateKeys(tt.algo)
+			assert.NoError(t, err)
+			assert.NotNil(t, priv)
+			assert.NotNil(t, pub)
+		})
+	}
+}
+
+func TestSavePrivateKey(t *testing.T) {
+	// Create temp dir
+	tmpDir, err := os.MkdirTemp("", "magi-crypto-test-priv")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	priv, _, err := generateKeys("rsa")
+	assert.NoError(t, err)
+
+	path := filepath.Join(tmpDir, "private.pem")
+	err = savePrivateKey(priv, path)
+	assert.NoError(t, err)
+
+	// Verify file exists and permissions
+	info, err := os.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	// Verify content is PEM
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	block, _ := pem.Decode(content)
+	assert.NotNil(t, block)
+	assert.Equal(t, "RSA PRIVATE KEY", block.Type)
+}
+
+func TestSavePublicKey(t *testing.T) {
+	// Create temp dir
+	tmpDir, err := os.MkdirTemp("", "magi-crypto-test-pub")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	_, pub, err := generateKeys("rsa")
+	assert.NoError(t, err)
+
+	path := filepath.Join(tmpDir, "public.pem")
+	err = savePublicKey(pub, path)
+	assert.NoError(t, err)
+
+	// Verify file exists and permissions
+	info, err := os.Stat(path)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0644), info.Mode().Perm())
+
+	// Verify content is PEM
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	block, _ := pem.Decode(content)
+	assert.NotNil(t, block)
+	assert.Equal(t, "PUBLIC KEY", block.Type)
+}
+
+func TestGeneratePublicKeyFromPrivate(t *testing.T) {
+	// Create temp dir
+	tmpDir, err := os.MkdirTemp("", "magi-crypto-test-extract")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Generate and save private key
+	priv, _, err := generateKeys("rsa")
+	assert.NoError(t, err)
+	privPath := filepath.Join(tmpDir, "private.pem")
+	err = savePrivateKey(priv, privPath)
+	assert.NoError(t, err)
+
+	// Extract public key
+	pubPath := filepath.Join(tmpDir, "public.pem")
+	err = generatePublicKeyFromPrivate(privPath, pubPath)
+	assert.NoError(t, err)
+
+	// Verify public key file
+	content, err := os.ReadFile(pubPath)
+	assert.NoError(t, err)
+	block, _ := pem.Decode(content)
+	assert.NotNil(t, block)
+	assert.Equal(t, "PUBLIC KEY", block.Type)
+
+	// Verify it matches the private key
+	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	assert.NoError(t, err)
+	assert.NotNil(t, pubKey)
+}

--- a/internal/cli/crypto/salt.go
+++ b/internal/cli/crypto/salt.go
@@ -28,6 +28,11 @@ func init() {
 }
 
 func runGenerateSalt(cmd *cobra.Command, args []string) {
+	if saltLength <= 0 {
+		pterm.Error.Println("Salt length must be greater than zero")
+		return
+	}
+
 	key := make([]byte, saltLength)
 	_, err := rand.Read(key)
 	if err != nil {

--- a/internal/cli/crypto/salt.go
+++ b/internal/cli/crypto/salt.go
@@ -1,0 +1,41 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var saltLength int
+
+var SaltCmd = &cobra.Command{
+	Use:   "salt",
+	Short: "Generate a random salt key",
+	Long:  `Generate a random salt key of a specified length.`,
+	Example: `  # Generate a 32-byte salt (default)
+  magi crypto salt
+
+  # Generate a 64-byte salt
+  magi crypto salt --length 64`,
+	Run: runGenerateSalt,
+}
+
+func init() {
+	SaltCmd.Flags().IntVarP(&saltLength, "length", "l", 32, "Salt length")
+}
+
+func runGenerateSalt(cmd *cobra.Command, args []string) {
+	key := make([]byte, saltLength)
+	_, err := rand.Read(key)
+	if err != nil {
+		pterm.Error.Printf("Failed to generate salt: %v\n", err)
+		return
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(key)
+	pterm.Success.Printf("Generated salt (%d bytes):\n", saltLength)
+	fmt.Println(encoded)
+}

--- a/internal/cli/crypto/salt_test.go
+++ b/internal/cli/crypto/salt_test.go
@@ -19,12 +19,14 @@ func TestSaltCmd(t *testing.T) {
 
 func TestRunGenerateSalt(t *testing.T) {
 	tests := []struct {
-		name   string
-		length int
+		name       string
+		length     int
+		expectSkip bool
 	}{
-		{"DefaultLength", 32},
-		{"CustomLength", 16},
-		{"LargeLength", 64},
+		{"DefaultLength", 32, false},
+		{"CustomLength", 16, false},
+		{"LargeLength", 64, false},
+		{"InvalidLength", -1, true},
 	}
 
 	for _, tt := range tests {
@@ -50,8 +52,13 @@ func TestRunGenerateSalt(t *testing.T) {
 
 			// Read captured output
 			var buf bytes.Buffer
-			_, _ = buf.ReadFrom(r)
-			output := buf.String()
+_, _ = buf.ReadFrom(r)
+output := buf.String()
+
+if tt.expectSkip {
+assert.Empty(t, strings.TrimSpace(output))
+return
+}
 
 			// Verify
 			lines := strings.Split(strings.TrimSpace(output), "\n")

--- a/internal/cli/crypto/salt_test.go
+++ b/internal/cli/crypto/salt_test.go
@@ -1,0 +1,87 @@
+package crypto
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSaltCmd(t *testing.T) {
+	cmd := SaltCmd
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "salt", cmd.Use)
+}
+
+func TestRunGenerateSalt(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{"DefaultLength", 32},
+		{"CustomLength", 16},
+		{"LargeLength", 64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			// Restore stdout at the end
+			defer func() {
+				os.Stdout = oldStdout
+			}()
+
+			// Set flag value
+			saltLength = tt.length
+
+			// Execute
+			runGenerateSalt(&cobra.Command{}, []string{})
+
+			// Close write end of pipe
+			w.Close()
+
+			// Read captured output
+			var buf bytes.Buffer
+			_, _ = buf.ReadFrom(r)
+			output := buf.String()
+
+			// Verify
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			// The last line should be the encoded salt
+			// pterm might add colors/formatting, so we look for the last non-empty line
+			var encodedSalt string
+			for i := len(lines) - 1; i >= 0; i-- {
+				if strings.TrimSpace(lines[i]) != "" {
+					encodedSalt = strings.TrimSpace(lines[i])
+					break
+				}
+			}
+
+			// If pterm output is mixed in, we might need to be more careful.
+			// But fmt.Println(encoded) should be clean if pterm writes to stderr or if we just look at the last line.
+			// However, pterm writes to stdout by default.
+			// Let's try to decode the last line.
+
+			// Clean up any potential ANSI codes if pterm added them to the salt line (unlikely for fmt.Println)
+			decoded, err := base64.StdEncoding.DecodeString(encodedSalt)
+			if err != nil {
+				// Try the line before, maybe there's a trailing newline issue
+				if len(lines) > 1 {
+					encodedSalt = strings.TrimSpace(lines[len(lines)-2])
+					decoded, err = base64.StdEncoding.DecodeString(encodedSalt)
+				}
+			}
+
+			assert.NoError(t, err, "Failed to decode salt: %s", encodedSalt)
+			assert.Equal(t, tt.length, len(decoded))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to magi-cli! 🎉

Please provide a clear and concise description of the changes in this pull request.
If applicable, link to any related issues.
-->

**Description**

Adds crypto command with subcommands: salt (random bytes), keyfile (MongoDB), keypair (RSA/ECDSA/Ed25519). Uses crypto/rand, sets 0400/0600 file perms, cobra patterns. No data leaves machine; local secrets via filesystem perms (no network). Includes tests/docs.

Security: No passphrase support, Windows perm tests fail, fragile stdout tests, dir 0755 group-accessible risk, arbitrary privkey read.
Testing: Unit tests added (fix Windows skips, stdout mocks recommended).
Docs: Updated commands.md (add explicit security callout), needs changelog/getting-started.

**Related Issues**

- None

**Checklist**

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/MagdielCAS/magi-cli/blob/main/docs/CONTRIBUTING.md) guidelines.
- [x] My code follows the project's style and formatting.
- [x] I have added or updated tests to cover my changes.
- [x] All new and existing tests pass.
- [x] I have updated the documentation to reflect my changes.

Branch under review: feat/crypto